### PR TITLE
Update ble plugin iOS implementation to not use deprecated apis

### DIFF
--- a/Source/Plugin.BLE.iOS/BleImplementation.cs
+++ b/Source/Plugin.BLE.iOS/BleImplementation.cs
@@ -4,6 +4,7 @@ using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Extensions;
 using Plugin.BLE.iOS;
+using UIKit;
 
 namespace Plugin.BLE
 {
@@ -13,7 +14,7 @@ namespace Plugin.BLE
 
         protected override void InitializeNative()
         {
-            _centralManager = new CBCentralManager(DispatchQueue.CurrentQueue);
+            _centralManager = new CBCentralManager(DispatchQueue.MainQueue);
             _centralManager.UpdatedState += (s, e) => State = GetState();
         }
 
@@ -29,7 +30,15 @@ namespace Plugin.BLE
 
         private BluetoothState GetState()
         {
-            return _centralManager.State.ToBluetoothState();
+            if (UIDevice.CurrentDevice.CheckSystemVersion(10, 0))
+            {
+                var manager = (CBManager)_centralManager;
+                return manager.State.ToBluetoothState();
+            }
+            else
+            {
+                return _centralManager.State.ToBluetoothState();
+            }
         }
     }
 }

--- a/Source/Plugin.BLE.iOS/Extensions/BluetoothStateExtension.cs
+++ b/Source/Plugin.BLE.iOS/Extensions/BluetoothStateExtension.cs
@@ -5,6 +5,27 @@ namespace Plugin.BLE.Extensions
 {
     public static class BluetoothStateExtension
     {
+        public static BluetoothState ToBluetoothState(this CBManagerState state)
+        {
+            switch (state)
+            {
+                case CBManagerState.Unknown:
+                    return BluetoothState.Unknown;
+                case CBManagerState.Resetting:
+                    return BluetoothState.Unknown;
+                case CBManagerState.Unsupported:
+                    return BluetoothState.Unavailable;
+                case CBManagerState.Unauthorized:
+                    return BluetoothState.Unauthorized;
+                case CBManagerState.PoweredOff:
+                    return BluetoothState.Off;
+                case CBManagerState.PoweredOn:
+                    return BluetoothState.On;
+                default:
+                    return BluetoothState.Unknown;
+            }
+        }
+
         public static BluetoothState ToBluetoothState(this CBCentralManagerState state)
         {
             switch (state)


### PR DESCRIPTION
This PR 

- Removes the usage of deprecated APIs in BleImplementation