### PR TITLE
CLOUD-6755 fix product control view model hanging

### DIFF
--- a/Source/Plugin.BLE.iOS/Adapter.cs
+++ b/Source/Plugin.BLE.iOS/Adapter.cs
@@ -70,6 +70,9 @@ namespace Plugin.BLE.iOS
                     device = new Device(this, e.Peripheral);
                 }
 
+                //make sure all cached services are cleared this will also clear characteristics and descriptors implicitly
+                ((Device)device).ClearServices();
+
                 _deviceConnectionRegistry[guid] = device;
                 HandleConnectedDevice(device);
             };


### PR DESCRIPTION
This PR
* Fixes the product control view model, hanging when going into it after reconnecting a bluetooth device. 
* It does so by ensuring that the cached services and characteristics, we are saving, will be cleared when ever you connect to a device