### PR TITLE
CLOUD-7372 do not close BluetoothGatt, but wait for a callback

### DIFF
--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -151,7 +151,6 @@ namespace Plugin.BLE.Android
         {
             //make sure everything is disconnected
             ((Device)device).Disconnect();
-            ((Device)device).CloseGatt();
         }
 
         public override async Task<IDevice> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default(ConnectParameters), CancellationToken cancellationToken = default(CancellationToken))


### PR DESCRIPTION
This PR
- Fixes an issue, where disconnecting android devices, would hang because the BlutoothGatt was closed too early, causing us not to receive any callbacks from the GattCallback