### PR TITLE
CLOUD-7696 thread safe access to dictionary

### DIFF
--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -30,6 +30,11 @@ namespace Plugin.BLE.Android
         /// </summary>
         public Dictionary<string, IDevice> ConnectedDeviceRegistry { get; }
 
+        /// <summary>
+        ///  Thread safety
+        /// </summary>
+        public object ConnectedDeviceRegistryLock { get; } = new object();
+
         public Adapter(BluetoothManager bluetoothManager)
         {
             _bluetoothManager = bluetoothManager;

--- a/Source/Plugin.BLE.Android/GattCallback.cs
+++ b/Source/Plugin.BLE.Android/GattCallback.cs
@@ -41,8 +41,6 @@ namespace Plugin.BLE.Android
         {
             base.OnConnectionStateChange(gatt, status, newState);
 
-            object deviceRegistryLock = new object();
-
             if (!gatt.Device.Address.Equals(_device.BluetoothDevice.Address))
             {
                 Trace.Message($"Gatt callback for device {_device.BluetoothDevice.Address} was called for device with address {gatt.Device.Address}. This shoud not happen. Please log an issue.");
@@ -68,7 +66,7 @@ namespace Plugin.BLE.Android
 
                         //Found so we can remove it
                         _device.IsOperationRequested = false;
-                        lock (deviceRegistryLock)
+                        lock (_adapter.ConnectedDeviceRegistryLock)
                         {
                             _adapter.ConnectedDeviceRegistry.Remove(gatt.Device.Address);
                         }
@@ -92,7 +90,7 @@ namespace Plugin.BLE.Android
                     //connection must have been lost, because the callback was not triggered by calling disconnect
                     Trace.Message($"Disconnected '{_device.Name}' by lost connection");
 
-                    lock (deviceRegistryLock)
+                    lock (_adapter.ConnectedDeviceRegistryLock)
                     {
                         _adapter.ConnectedDeviceRegistry.Remove(gatt.Device.Address);
                     }
@@ -136,7 +134,7 @@ namespace Plugin.BLE.Android
                     }
                     else
                     {
-                        lock (deviceRegistryLock)
+                        lock (_adapter.ConnectedDeviceRegistryLock)
                         {
                             _adapter.ConnectedDeviceRegistry[gatt.Device.Address] = _device;
                         }


### PR DESCRIPTION
Only reason for a null ref inside a dictionary I can think of is threading issues. Hence the lock

https://rink.hockeyapp.net/manage/apps/435800/app_versions/98/crash_reasons/265455573?type=overview

Xamarin caused by: android.runtime.JavaProxyThrowable: System.NullReferenceException: Object reference not set to an instance of an object
  at System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) <0xc6e84128 + 0x001a8> in <a80c8ef19c37407c8a781e4fdcb788c1>:0 
  at System.Collections.Generic.Dictionary`2[TKey,TValue].set_Item (TKey key, TValue value) <0xc6e835c8 + 0x00013> in <a80c8ef19c37407c8a781e4fdcb788c1>:0 
  at Plugin.BLE.Android.GattCallback.OnConnectionStateChange (Android.Bluetooth.BluetoothGatt gatt, Android.Bluetooth.GattStatus status, Android.Bluetooth.ProfileState newState) <0xc3914968 + 0x00567> in <63f18d755a66468ba05b758afe7dc9e2>:0 
  at Android.Bluetooth.BluetoothGattCallback.n_OnConnectionStateChange_Landroid_bluetooth_BluetoothGatt_II (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_gatt, System.Int32 native_status, System.Int32 native_newState) <0xc63a4214 + 0x0007b> in <02e9fe16f55545b9a0f5797e9175cc5a>:0 
  at (wrapper dynamic-method) System.Object.7bde7cad-a570-4f2b-a6eb-bc06d7afe51a(intptr,intptr,intptr,int,int)
	at md5b8da2e4cd7b57e43a9b1e62f6e4aa245.GattCallback.n_onConnectionStateChange(Native Method)
	at md5b8da2e4cd7b57e43a9b1e62f6e4aa245.GattCallback.onConnectionStateChange(GattCallback.java:38)
	at android.bluetooth.BluetoothGatt$1$4.run(BluetoothGatt.java:262)
	at android.bluetooth.BluetoothGatt.runOrQueueCallback(BluetoothGatt.java:770)
	at android.bluetooth.BluetoothGatt.access$200(BluetoothGatt.java:39)
	at android.bluetooth.BluetoothGatt$1.onClientConnectionState(BluetoothGatt.java:257)
	at android.bluetooth.IBluetoothGattCallback$Stub.onTransact(IBluetoothGattCallback.java:71)
	at android.os.Binder.execTransact(Binder.java:733)