### PR TITLE
Handle multiple threads closing and asking for services

### DIFF
--- a/Source/Plugin.BLE.Abstractions/DeviceBase.cs
+++ b/Source/Plugin.BLE.Abstractions/DeviceBase.cs
@@ -69,7 +69,7 @@ namespace Plugin.BLE.Abstractions
                     services = await GetServicesNativeAsync();
                 }
                 
-                if(services != null)
+                if (services != null)
                 {
                     lock (_servicesLock)
                     {

--- a/Source/Plugin.BLE.Abstractions/DeviceBase.cs
+++ b/Source/Plugin.BLE.Abstractions/DeviceBase.cs
@@ -68,10 +68,13 @@ namespace Plugin.BLE.Abstractions
                 {
                     services = await GetServicesNativeAsync();
                 }
-
-                lock (_servicesLock)
+                
+                if(services != null)
                 {
-                    KnownServices.AddRange(services);
+                    lock (_servicesLock)
+                    {
+                        KnownServices.AddRange(services);
+                    }
                 }
             }
 

--- a/Source/Plugin.BLE.Abstractions/DeviceBase.cs
+++ b/Source/Plugin.BLE.Abstractions/DeviceBase.cs
@@ -21,9 +21,16 @@ namespace Plugin.BLE.Abstractions
 
         public static void CancelEverything(this ICancellationMaster cancellationMaster)
         {
-            cancellationMaster.TokenSource?.Cancel();
-            cancellationMaster.TokenSource?.Dispose();
-            cancellationMaster.TokenSource = null;
+            if (cancellationMaster.TokenSource != null)
+            {
+                //Cleanup can happen from many threads. Avoid disposed exceptions
+                lock (cancellationMaster.TokenSource)
+                {
+                    cancellationMaster.TokenSource?.Cancel();
+                    cancellationMaster.TokenSource?.Dispose();
+                    cancellationMaster.TokenSource = null;
+                }
+            }
         }
 
         public static void CancelEverythingAndReInitialize(this ICancellationMaster cancellationMaster)
@@ -35,6 +42,7 @@ namespace Plugin.BLE.Abstractions
 
     public abstract class DeviceBase : IDevice, ICancellationMaster
     {
+        private object _servicesLock = new object();
         protected readonly IAdapter Adapter;
         protected readonly List<IService> KnownServices = new List<IService>();
         public Guid Id { get; protected set; }
@@ -53,11 +61,17 @@ namespace Plugin.BLE.Abstractions
 
         public async Task<IList<IService>> GetServicesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (!KnownServices.Any())
+            if (KnownServices.Count == 0)
             {
+                IEnumerable<IService> services = null;
                 using (var source = this.GetCombinedSource(cancellationToken))
                 {
-                    KnownServices.AddRange(await GetServicesNativeAsync());
+                    services = await GetServicesNativeAsync();
+                }
+
+                lock (_servicesLock)
+                {
+                    KnownServices.AddRange(services);
                 }
             }
 
@@ -100,21 +114,24 @@ namespace Plugin.BLE.Abstractions
         {
             this.CancelEverythingAndReInitialize();
 
-            if (KnownServices != null)
+            lock (_servicesLock)
             {
-                foreach (var service in KnownServices)
+                if (KnownServices != null)
                 {
-                    try
+                    foreach (var service in KnownServices)
                     {
-                        service.Dispose();
+                        try
+                        {
+                            service.Dispose();
+                        }
+                        catch (Exception ex)
+                        {
+                            Trace.Message("Exception while cleanup of service: {0}", ex.Message);
+                        }
                     }
-                    catch (Exception ex)
-                    {
-                        Trace.Message("Exception while cleanup of service: {0}", ex.Message);
-                    }
-                }
 
-                KnownServices.Clear();
+                    KnownServices.Clear();
+                }
             }
         }
 


### PR DESCRIPTION
PR fixes two crashes from Android logs. 

First is collection changed exception. Apparently we can try to connect while we're still cleaning up and the code is not thread safe. 

Secondly more than one thread can try to disconnect which can cause a token disposed exception. This is now also thread safe