### PR TITLE
ConnectToNative flow

### DIFF
--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -12,7 +12,6 @@ using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Extensions;
 using Object = Java.Lang.Object;
 using Trace = Plugin.BLE.Abstractions.Trace;
-using Android.App;
 using Plugin.BLE.Abstractions.EventArgs;
 
 namespace Plugin.BLE.Android
@@ -189,42 +188,40 @@ namespace Plugin.BLE.Android
         {
             if (uuid == Guid.Empty)
             {
-                CancellationTokenSource connectTokenSource = new CancellationTokenSource();
-                using (cancellationToken.Register(() => connectTokenSource.Cancel()))
+                var stopToken = new CancellationTokenSource();
+                var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(stopToken.Token, cancellationToken).Token;
+                var taskCompletionSource = new TaskCompletionSource<IDevice>();
+                EventHandler<DeviceEventArgs> handler = (sender, args) =>
                 {
-                    var taskCompletionSource = new TaskCompletionSource<IDevice>();
-                    EventHandler<DeviceEventArgs> handler = (sender, args) =>
+                    if (taskCompletionSource.TrySetResult(args.Device))
                     {
-                        if (taskCompletionSource.TrySetResult(args.Device))
-                        {
-
-                        }
-                    };
-
-                    try
-                    {
-                        DeviceDiscovered += handler;
-                        async Task<IDevice> WaitAsync()
-                        {
-                            await Task.Delay(MaxScanTimeMS);
-                            return null;
-                        }
-
-                        var scanTask = StartScanningForDevicesAsync(deviceFilter: deviceFilter, cancellationToken: connectTokenSource.Token);
-                        var device = await await Task.WhenAny(taskCompletionSource.Task, WaitAsync());
-
-                        // make sure to wait for the scan to complete before connecting to avoid doing multiple things at once. If a
-                        // device was matched, then it should already have completed through the cancellation, otherwise it is
-                        // controlled by the scan timeout
-                        await scanTask;
-
-                        await ConnectToDeviceAsync(device, new ConnectParameters(false, true), cancellationToken);
-                        return device;
+                        stopToken.Cancel();
                     }
-                    finally
+                };
+
+                try
+                {
+                    DeviceDiscovered += handler;
+                    async Task<IDevice> WaitAsync()
                     {
-                        DeviceDiscovered -= handler;
+                        await Task.Delay(MaxScanTimeMS);
+                        return null;
                     }
+
+                    var scanTask = StartScanningForDevicesAsync(deviceFilter: deviceFilter, cancellationToken: linkedToken);
+                    var device = await await Task.WhenAny(taskCompletionSource.Task, WaitAsync());
+
+                    // make sure to wait for the scan to complete before connecting to avoid doing multiple things at once. If a
+                    // device was matched, then it should already have completed through the cancellation, otherwise it is
+                    // controlled by the scan timeout
+                    await scanTask;
+
+                    await ConnectToDeviceAsync(device, new ConnectParameters(false, true), cancellationToken);
+                    return device;
+                }
+                finally
+                {
+                    DeviceDiscovered -= handler;
                 }
             }
             else

--- a/Source/Plugin.BLE.iOS/Adapter.cs
+++ b/Source/Plugin.BLE.iOS/Adapter.cs
@@ -411,8 +411,10 @@ namespace Plugin.BLE.iOS
 
                 if (peripheral.Name == friendlyName)
                 {
-                    stopToken.Cancel();
-                    taskCompletionSource.TrySetResult(peripheral);
+                    if (taskCompletionSource.TrySetResult(peripheral))
+                    {
+                        stopToken.Cancel();
+                    }
                 }
             };
 


### PR DESCRIPTION
Aligning how ConnectToNative works, specifically adding a local cancellationtoken that is cancelling the scan as soon as a device is discovered through the filter. This was not the case (on Android) and should have the effect that a device is discovered/connected quicker. This is specifically used in FastPair scenarios where the UUID is randomized so we need to be finding devices through advertisement record matching