### PR TITLE
Check if product was already discovered, and stop scanning before sta…

### DIFF
--- a/Source/Plugin.BLE.iOS/Adapter.cs
+++ b/Source/Plugin.BLE.iOS/Adapter.cs
@@ -420,6 +420,19 @@ namespace Plugin.BLE.iOS
                 linkedToken.Register(() => taskCompletionSource.TrySetCanceled());
 
                 DeviceDiscovered += handler;
+
+                // We could already be scanning, if that's the case, check if we have found any devices that matches
+                if (IsScanning)
+                {
+                    var foundDevice = DiscoveredDevices.FirstOrDefault(x => deviceFilter(x));
+                    if (foundDevice != null)
+                    {
+                        return foundDevice.NativeDevice as CBPeripheral;
+                    }
+                }
+
+                await StopScanningForDevicesAsync();
+
                 await StartScanningForDevicesAsync(
                     deviceFilter: deviceFilter,
                     cancellationToken: linkedToken);


### PR DESCRIPTION
This PR
- Fixes an issue I discovered, that happened after setup. When we do not stop scanning, the ConnectAsync method could end up trying to scan for products that wasn't already discovered. Because of a previous scan, the product was already found, and hence the `ScanForPeripheral` didn't find anything.

To Accommodate this, I do a check, to see if we already found the product we try to scan for. If we have, we'll return that. 
Otherwise, we'll always ensure that if any scanning is running, we'll stop it.

One could argue that we should ensure our scanning never runs without a timeout like it seems to do somewhere in setup. I however, still think that it is a good idea, to ensure that the scanning is stopped before starting a new one
