### PR TITLE
CLOUD-9939 check if any devices was already discovered

### DIFF
--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -208,6 +208,15 @@ namespace Plugin.BLE.Android
                         return null;
                     }
 
+                    if (IsScanning)
+                    {
+                        var foundDevice = DiscoveredDevices.FirstOrDefault(x => deviceFilter(x));
+                        if (foundDevice != null)
+                        {
+                            return foundDevice;
+                        }
+                    }
+
                     var scanTask = StartScanningForDevicesAsync(deviceFilter: deviceFilter, cancellationToken: linkedToken);
                     var device = await await Task.WhenAny(taskCompletionSource.Task, WaitAsync());
 


### PR DESCRIPTION
This PR
- Fixes an issue where it was impossible to connect if a scanning was already started