### PR TITLE
fix potential npe if service discovery fails

### DIFF
--- a/Source/Plugin.BLE.Android/Device.cs
+++ b/Source/Plugin.BLE.Android/Device.cs
@@ -68,7 +68,14 @@ namespace Plugin.BLE.Android
                 execute: () => GattServer.DiscoverServices(),
                 getCompleteHandler: (complete, reject) => ((sender, args) =>
                 {
-                    complete(GattServer.Services.Select(service => new Service(service, GattServer, _gattCallback, this)));
+                    if (GattServer.Services is null)
+                    {
+                        complete(new List<IService>());
+                    }
+                    else
+                    {
+                        complete(GattServer.Services.Select(service => new Service(service, GattServer, _gattCallback, this))); // this thows NPE
+                    }
                 }),
                 subscribeComplete: handler => _gattCallback.ServicesDiscovered += handler,
                 unsubscribeComplete: handler => _gattCallback.ServicesDiscovered -= handler,


### PR DESCRIPTION
If service discovery fails to return a list of services due to a bad connection, it throws an NPE and crashes the app.
Added a check to avoid throwing the NPE.